### PR TITLE
Redundant Import Statement

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,3 +17,7 @@ if __name__ == '__main__':
 
 // TODO: Improvement needed - Redundant import statement
 // The 'Flask' and 'jsonify' modules are imported twice. This is unnecessary and can lead to confusion.
+
+
+// TODO: Improvement needed - Redundant Import Statement
+// The 'Flask' and 'jsonify' modules are imported twice. This is unnecessary and can lead to confusion. It's best to import all necessary modules at the beginning of the file.


### PR DESCRIPTION
The 'Flask' and 'jsonify' modules are imported twice. This is unnecessary and can lead to confusion. It's best to import all necessary modules at the beginning of the file.

Instructions: Add a data endpoint at /data that returns an array of hardcoded numbers as a placeholder

Automatically generated by Dexter