### PR TITLE
Missing Data Endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,3 +17,8 @@ if __name__ == '__main__':
 
 // TODO: Improvement needed - Redundant import statement
 // The 'Flask' and 'jsonify' modules are imported twice. This is unnecessary and can lead to confusion.
+
+
+@app.route('/data')
+def data():
+    return jsonify([1, 2, 3, 4, 5])


### PR DESCRIPTION
The application lacks a '/data' endpoint that returns an array of hardcoded numbers as a placeholder. This endpoint is necessary as per the implementation instructions.

Instructions: Add a data endpoint at /data that returns an array of hardcoded numbers as a placeholder

Automatically generated by Dexter