### PR TITLE
Missing unit test for /data endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,3 +22,17 @@ if __name__ == '__main__':
 @app.route('/data')
 def data():
     return jsonify([1, 2, 3, 4, 5])
+
+import unittest
+import app
+
+class TestDataEndpoint(unittest.TestCase):
+    def setUp(self):
+        self.app = app.app.test_client()
+    def test_data_endpoint(self):
+        response = self.app.get('/data')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), [1, 2, 3, 4, 5])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
There are no unit tests for the /data endpoint. Unit tests are crucial for ensuring the correctness of the code. They help to identify bugs early in the development cycle, making the bugs easier and cheaper to fix.

Instructions: Add unit tests for the /data endpoint that verifies it returns an array of numbers

Automatically generated by Dexter