### PR TITLE
Missing search endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,9 @@
+import unittest
+import app
 from flask import Flask, jsonify
 
 app = Flask(__name__)
+
 
 @app.route('/health')
 def health_check():
@@ -10,6 +13,7 @@ def health_check():
         'status': 'healthy',
         'message': 'Service is up and running'
     })
+
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8080, debug=False)
@@ -23,16 +27,16 @@ if __name__ == '__main__':
 def data():
     return jsonify([1, 2, 3, 4, 5])
 
-import unittest
-import app
 
 class TestDataEndpoint(unittest.TestCase):
     def setUp(self):
         self.app = app.app.test_client()
+
     def test_data_endpoint(self):
         response = self.app.get('/data')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get_json(), [1, 2, 3, 4, 5])
+
 
 if __name__ == '__main__':
     unittest.main()
@@ -42,3 +46,13 @@ try:
 except Exception as e:
     app.logger.error(f'Error occurred: {e}')
     return jsonify({'error': 'An error occurred'}), 500
+
+
+@app.route('/search')
+def search():
+    from elasticsearch import Elasticsearch
+    es = Elasticsearch()
+    query = request.args.get('q')
+    result = es.search(
+        index='my-index', body={'query': {'match': {'_all': query}}})
+    return jsonify(result)


### PR DESCRIPTION
The application lacks a search endpoint that queries an Elasticsearch instance. This endpoint should be added, along with corresponding unit tests.

Instructions: add a search endpoint, it returns queries from the elastic search instance. add unit tests too

Automatically generated by Dexter