### PR TITLE
Missing test for health_check endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,3 +47,10 @@ try:
 except Exception as e:
     app.logger.error(f'Error occurred: {e}')
     return jsonify({'error': 'An error occurred'}), 500
+
+
+def test_health_check_endpoint(self):
+    response = self.app.get('/health')
+    self.assertEqual(response.status_code, 200)
+    self.assertEqual(response.get_json(), {
+                     'status': 'healthy', 'message': 'Service is up and running'})


### PR DESCRIPTION
## Issue 1: Missing test for health_check endpoint
There is a test for the '/data' endpoint but not for the '/health' endpoint. It's important to have tests for all endpoints to ensure they are working as expected.

---

Instructions: Test multiple issue analysis

Automatically generated by Dexter