### PR TITLE
Fix 3 issues in test/test.py

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -1,16 +1,19 @@
 class TestDataEndpoint(unittest.TestCase):
+    DATA_ENDPOINT = '/data'
+
     def setUp(self):
         self.app = app.test_client()
 
-    def test_data_endpoint(self):
+    def test_data_endpoint_constant(self):
         DATA_ENDPOINT = '/data'
 
-    def test_data_endpoint(self):
+    def test_data_endpoint_response(self):
         response = self.app.get(self.DATA_ENDPOINT)
         self.assertEqual(response.status_code, 200)
         self.assertListEqual(response.get_json(), [1, 2, 3, 4, 5])
 
 
-def test_invalid_endpoint(self):
-    response = self.app.get('/invalid')
-    self.assertEqual(response.status_code, 404)
+def test_invalid_endpoint():
+    app = TestDataEndpoint()
+    response = app.app.get('/invalid')
+    app.assertEqual(response.status_code, 404)


### PR DESCRIPTION
## Issue 1: Incorrect attribute reference in test_invalid_endpoint
In the `test_invalid_endpoint` function, `self` is used to reference the `app` attribute, but `self` is not defined in this context since the function is not part of the `TestDataEndpoint` class. This will cause an `AttributeError` when running the test.

---

## Issue 2: DATA_ENDPOINT constant defined in wrong scope
The `DATA_ENDPOINT` constant is defined inside the `test_data_endpoint` method of the `TestDataEndpoint` class. However, it seems like this constant should be defined at the class level so it can be accessed by both test methods. Defining it inside a method limits its scope to that method only.

---

## Issue 3: Duplicate test method name
The `TestDataEndpoint` class has two methods with the same name `test_data_endpoint`. This is not allowed in Python and will cause issues when running the tests. Each test method should have a unique name that describes what it is testing.

---

Instructions: --instructions refactor and improve, remove duplicates

Automatically generated by Dexter