### PR TITLE
Inefficient user query in get_users

### DIFF
--- a/app.py
+++ b/app.py
@@ -76,8 +76,21 @@ def create_user():
 
 @app.route('/users', methods=['GET'])
 def get_users():
-    users = User.query.all()
-    return jsonify([user.to_dict() for user in users])
+    page = request.args.get('page', 1, type=int)
+    per_page = request.args.get('per_page', 10, type=int)
+    
+    # Limit maximum per_page to prevent abuse
+    per_page = min(per_page, 100)
+    
+    pagination = User.query.paginate(page=page, per_page=per_page, error_out=False)
+    users = pagination.items
+    
+    return jsonify({
+        'users': [user.to_dict() for user in users],
+        'total': pagination.total,
+        'pages': pagination.pages,
+        'current_page': page
+    })
 
 
 @app.route('/users/<int:user_id>', methods=['GET'])


### PR DESCRIPTION
## Issue 1: Inefficient user query in get_users
The get_users endpoint retrieves all users without pagination, which could cause performance issues with a large number of users.

---

Instructions: Add sqlalchemy user model and endpoints, dont comment stuff out, if it needs to go , remove it, you have complete authority to refactor the entire file, be aggressive and energetic, provide the best version of this file that could ever be made --debug --max-prs 3

Automatically generated by Dexter