### PR TITLE
Rate Limiting Commented Out

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,8 +66,8 @@ def data():
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 
-# Add to imports and initialize with app
-# limiter = Limiter(app, key_func=get_remote_address)
+# Initialize rate limiter
+limiter = Limiter(app, key_func=get_remote_address)
 
 @app.route('/users', methods=['POST'])
 # @limiter.limit("5 per minute")


### PR DESCRIPTION
## Issue 1: Rate Limiting Commented Out
The rate limiting functionality is imported but commented out, leaving the API vulnerable to abuse. Rate limiting should be enabled for security.

---

Instructions: Implement as needed, NO PLACEHOLDERS, NO ADDED COMMENTS ONLY WITHOUT CODE, FULLY FILL OUT ALL DETAILS --debug --max-prs 8

Automatically generated by Dexter