### PR TITLE
Rate Limiting Decorator Commented Out

### DIFF
--- a/app.py
+++ b/app.py
@@ -70,7 +70,7 @@ from flask_limiter.util import get_remote_address
 # limiter = Limiter(app, key_func=get_remote_address)
 
 @app.route('/users', methods=['POST'])
-# @limiter.limit("5 per minute")
+@limiter.limit("5 per minute")
 def create_user():
     data = request.get_json()
     


### PR DESCRIPTION
## Issue 1: Rate Limiting Decorator Commented Out
The rate limiting decorator for the create_user endpoint is commented out, making the endpoint vulnerable to brute force attacks.

---

Instructions: Implement as needed, NO PLACEHOLDERS, NO ADDED COMMENTS ONLY WITHOUT CODE, FULLY FILL OUT ALL DETAILS --debug --max-prs 8

Automatically generated by Dexter