### PR TITLE
Missing Error Handling in get_users Pagination

### DIFF
--- a/app.py
+++ b/app.py
@@ -120,7 +120,19 @@ def get_users():
     # Limit maximum per_page to prevent abuse
     per_page = min(per_page, 100)
     
-    pagination = User.query.paginate(page=page, per_page=per_page, error_out=False)
+    try:
+        pagination = User.query.paginate(page=page, per_page=per_page, error_out=False)
+        users = pagination.items
+        
+        return jsonify({
+            'users': [user.to_dict() for user in users],
+            'total': pagination.total,
+            'pages': pagination.pages,
+            'current_page': page
+        })
+    except Exception as e:
+        app.logger.error(f"Pagination error: {str(e)}")
+        return jsonify({'error': 'Failed to retrieve users'}), 500
     users = pagination.items
     
     return jsonify({


### PR DESCRIPTION
## Issue 1: Missing Error Handling in get_users Pagination
The paginate method may raise exceptions if invalid page numbers are provided, but there's no error handling for this case.

---

Instructions: Implement as needed, NO PLACEHOLDERS, NO ADDED COMMENTS ONLY WITHOUT CODE, FULLY FILL OUT ALL DETAILS --debug --max-prs 8

Automatically generated by Dexter