### PR TITLE
Fix: Hardcoded Database URI

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,8 @@ db = SQLAlchemy()
 
 def create_app(config=None):
     flask_app = Flask(__name__)
-    flask_app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///users.db'
+    import os
+    flask_app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URI', 'sqlite:///users.db')
     flask_app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     
     if config:


### PR DESCRIPTION
# Hardcoded Database URI

**Issue ID:** SECURITY-001

## Description
Database URI is hardcoded in the application code instead of being loaded from environment variables.

## Changes
### Original Code
```
    flask_app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///users.db'
```

### Suggested Code
```
    import os
    flask_app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URI', 'sqlite:///users.db')
```
