### PR TITLE
Fix: Misplaced unittest Import

### DIFF
--- a/app.py
+++ b/app.py
@@ -206,7 +206,15 @@ def delete_user(user_id):
     return jsonify({'message': 'User deleted successfully'})
 
 
+import logging
+import re
 import unittest
+
+from flask import Flask, jsonify, request
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+from flask_sqlalchemy import SQLAlchemy
+from werkzeug.security import check_password_hash, generate_password_hash
 
 
 class TestDataEndpoint(unittest.TestCase):


### PR DESCRIPTION
# Misplaced unittest Import

**Issue ID:** ARCH-003

## Description
The unittest import is placed at the end of the file instead of at the top with other imports.

## Changes
### Original Code
```
import unittest
```

### Suggested Code
```
import logging
import re
import unittest

from flask import Flask, jsonify, request
from flask_limiter import Limiter
from flask_limiter.util import get_remote_address
from flask_sqlalchemy import SQLAlchemy
from werkzeug.security import check_password_hash, generate_password_hash
```
