### PR TITLE
Fix: Missing Error Handling in update_user

### DIFF
--- a/app.py
+++ b/app.py
@@ -193,8 +193,13 @@ def update_user(user_id):
     if 'password' in data:
         user.set_password(data['password'])
     
-    db.session.commit()
-    return jsonify(user.to_dict())
+    try:
+        db.session.commit()
+        return jsonify(user.to_dict())
+    except Exception as e:
+        db.session.rollback()
+        app.logger.error(f"Update user error: {str(e)}")
+        return jsonify({'error': 'Failed to update user'}), 500
 
 
 @app.route('/users/<int:user_id>', methods=['DELETE'])


### PR DESCRIPTION
# Missing Error Handling in update_user

**Issue ID:** ERR-001

## Description
The update_user route lacks error handling for database operations which could fail.

## Changes
### Original Code
```
    db.session.commit()
    return jsonify(user.to_dict())
```

### Suggested Code
```
    try:
        db.session.commit()
        return jsonify(user.to_dict())
    except Exception as e:
        db.session.rollback()
        app.logger.error(f"Update user error: {str(e)}")
        return jsonify({'error': 'Failed to update user'}), 500
```
