### PR TITLE
Fix: Duplicate Code in get_users Function

### DIFF
--- a/app.py
+++ b/app.py
@@ -150,14 +150,7 @@ def get_users():
     except Exception as e:
         app.logger.error(f"Pagination error: {str(e)}")
         return jsonify({'error': 'Failed to retrieve users'}), 500
-    users = pagination.items
-    
-    return jsonify({
-        'users': [user.to_dict() for user in users],
-        'total': pagination.total,
-        'pages': pagination.pages,
-        'current_page': page
-    })
+# Remove this duplicate code block as it's unreachable
 
 
 @app.route('/users/<int:user_id>', methods=['GET'])


### PR DESCRIPTION
# Duplicate Code in get_users Function

**Issue ID:** BUG-001

## Description
The get_users function has duplicate code that assigns and returns users data. The second block is unreachable.

## Changes
### Original Code
```
    users = pagination.items
    
    return jsonify({
        'users': [user.to_dict() for user in users],
        'total': pagination.total,
        'pages': pagination.pages,
        'current_page': page
    })
```

### Suggested Code
```
# Remove this duplicate code block as it's unreachable
```
