### PR TITLE
Fix: Duplicate code in get_users route

### DIFF
--- a/app.py
+++ b/app.py
@@ -159,14 +159,7 @@ def get_users():
     except Exception as e:
         app.logger.error(f"Pagination error: {str(e)}")
         return jsonify({'error': 'Failed to retrieve users'}), 500
-    users = pagination.items
-    
-    return jsonify({
-        'users': [user.to_dict() for user in users],
-        'total': pagination.total,
-        'pages': pagination.pages,
-        'current_page': page
-    })
+    # This duplicate code should be removed as it's already handled in the try block
 
 
 @app.route('/users/<int:user_id>', methods=['GET'])


### PR DESCRIPTION
# Duplicate code in get_users route

**Issue ID:** DUP-001

## Description
The users variable is assigned twice and there's duplicate return logic in the get_users function.

## Changes
### Original Code
```
    users = pagination.items
    
    return jsonify({
        'users': [user.to_dict() for user in users],
        'total': pagination.total,
        'pages': pagination.pages,
        'current_page': page
    })
```

### Suggested Code
```
    # This duplicate code should be removed as it's already handled in the try block
```


