### PR TITLE
Fix: Hardcoded secret key

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ def create_app(config=None):
     import os
     flask_app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URI', 'sqlite:///users.db')
     flask_app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    flask_app.config['SECRET_KEY'] = 'your-secret-key-here'  # Should be loaded from environment variables in production
+    flask_app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'dev-key-for-testing-only')
     
     if config:
         flask_app.config.update(config)


### PR DESCRIPTION
# Hardcoded secret key

**Issue ID:** CONFIG-001

## Description
Secret keys should not be hardcoded in the source code. They should be loaded from environment variables.

## Changes
### Original Code
```
    flask_app.config['SECRET_KEY'] = 'your-secret-key-here'  # Should be loaded from environment variables in production
```

### Suggested Code
```
    flask_app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'dev-key-for-testing-only')
```


 --auto-fix --create-pr