### PR TITLE
Fix: Limiter initialized with undefined app

### DIFF
--- a/app.py
+++ b/app.py
@@ -83,7 +83,8 @@ from flask_sqlalchemy import SQLAlchemy
 from werkzeug.security import check_password_hash, generate_password_hash
 
 # Initialize rate limiter
-limiter = Limiter(app, key_func=get_remote_address)
+limiter = Limiter(key_func=get_remote_address)
+limiter.init_app(app)
 
 @app.route('/users', methods=['POST'])
 @limiter.limit("5 per minute")


### PR DESCRIPTION
# Limiter initialized with undefined app

**Issue ID:** INIT-001

## Description
The Limiter is initialized with 'app' before the app is fully configured. It should be initialized after app creation.

## Changes
### Original Code
```
limiter = Limiter(app, key_func=get_remote_address)
```

### Suggested Code
```
limiter = Limiter(key_func=get_remote_address)
limiter.init_app(app)
```


 --auto-fix --create-pr