### PR TITLE
Fix: Missing password validation in update_user

### DIFF
--- a/app.py
+++ b/app.py
@@ -193,6 +193,8 @@ def update_user(user_id):
         user.email = data['email']
         
     if 'password' in data:
+        if not is_strong_password(data['password']):
+            return jsonify({'error': 'Password too weak'}), 400
         user.set_password(data['password'])
     
     db.session.commit()


### PR DESCRIPTION
# Missing password validation in update_user

**Issue ID:** VALID-002

## Description
The update_user function doesn't validate password strength when updating a user's password.

## Changes
### Original Code
```
    if 'password' in data:
        user.set_password(data['password'])
```

### Suggested Code
```
    if 'password' in data:
        if not is_strong_password(data['password']):
            return jsonify({'error': 'Password too weak'}), 400
        user.set_password(data['password'])
```


 --auto-fix --create-pr